### PR TITLE
Ensure IDataProtectionProvider is registered

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # IdentityServer3 Integration Library for ASP.NET 5
+
+Data protection must be enabled for your ASP.NET 5 application to use this library. Example:
+
+```
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddDataProtection();
+    }
+}
+```

--- a/src/IdentityServer3.Integration.AspNet/IdentityServerApplicationBuilderExtensions.cs
+++ b/src/IdentityServer3.Integration.AspNet/IdentityServerApplicationBuilderExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.Builder
                 addToPipeline(next =>
                 {
                     var builder = new Microsoft.Owin.Builder.AppBuilder();
-                    var provider = app.ApplicationServices.GetService<DataProtection.IDataProtectionProvider>();
+                    var provider = app.ApplicationServices.GetRequiredService<DataProtection.IDataProtectionProvider>();
 
                     builder.Properties["security.DataProtectionProvider"] = new DataProtectionProviderDelegate(purposes =>
                     {

--- a/src/IdentityServer3.Integration.AspNet/IdentityServerApplicationBuilderExtensions.cs
+++ b/src/IdentityServer3.Integration.AspNet/IdentityServerApplicationBuilderExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.Builder
                 addToPipeline(next =>
                 {
                     var builder = new Microsoft.Owin.Builder.AppBuilder();
-					var provider = app.ApplicationServices.GetService<DataProtection.IDataProtectionProvider>();
+                    var provider = app.ApplicationServices.GetService<DataProtection.IDataProtectionProvider>();
 
                     builder.Properties["security.DataProtectionProvider"] = new DataProtectionProviderDelegate(purposes =>
                     {


### PR DESCRIPTION
For bare bones ASP.NET 5 applications, there is no `IDataProtectionProvider` registered by default. Add instructions how to enable it and make sure it's registered when we ask for it. Otherwise the integration will fail with a `NullReferenceException` with an obscure stacktrace.